### PR TITLE
Enable manage_false capability on Solaris

### DIFF
--- a/templates/master_solaris.erb
+++ b/templates/master_solaris.erb
@@ -13,7 +13,7 @@
 <% if @maps_real[key]['maptype'] -%>
 /<%= @maps_real[key]['mountpoint'] -%> <%= key -%>
 <% else -%>
-/<%= @maps_real[key]['mountpoint'] %> /etc/auto.<%= key -%>
+/<%= @maps_real[key]['mountpoint'] %> <% if @maps_real[key]['manage'] == nil or @maps_real[key]['manage'] == true -%>/etc/auto.<%= key -%><% else -%>-null<% end -%>
 <% end -%>
 <% else -%>
 /<%= key %> /etc/auto.<%= key -%>


### PR DESCRIPTION
Change would allow Solaris 10 to use the manage::false flag, and add
-null on mount points we do NOT want to be auto mounted. Tested on
Solaris 10.
