### PR TITLE
Puppet 4.x & 5.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,84 +1,51 @@
 ---
 language: ruby
 
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.3.1
+cache: bundler
 
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4.0.0"
-    - PUPPET_GEM_VERSION="~> 4.1.0"
-    - PUPPET_GEM_VERSION="~> 4.2.0"
-    - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4.6.0"
-    - PUPPET_GEM_VERSION="~> 4"
+before_install:
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem update bundler
+  - gem --version
+  - bundle -v
 
 sudo: false
 
-script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.5.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.6.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.5.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.6.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 3.7.0"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 3"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5"
 
 notifications:
-  email: false
+email: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 1.2.0'
-gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet'
-gem 'puppet-lint', '>= 1.0', '< 3.0'
+gem 'facter', '~> 1.0'   if ENV['PUPPET_GEM_VERSION'] < '~> 3.5.0'
+gem 'facter', '>= 2.2.0' if ENV['PUPPET_GEM_VERSION'] >= '~> 3.5.0'
+
+gem 'rspec-puppet', '~> 2.0'
+gem 'puppet-lint', '~> 2.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
@@ -23,7 +23,21 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'rspec',              '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rake',               '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'json',               '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure',          '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION <= '1.9.3'
+gem 'metadata-json-lint'             if RUBY_VERSION > '1.9.3'
+gem 'public_suffix',      '~> 1.1.0' if RUBY_VERSION < '2.1.1' && RUBY_VERSION >= '1.9'
+gem 'public_suffix',      '1.3.0'    if RUBY_VERSION < '1.9'
+
+gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
+gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0' && RUBY_VERSION >= '1.9'
+gem 'parallel_tests',         '1.0.9',    :require => false if RUBY_VERSION < '1.9'
+gem 'parallel',               '1.3.3.1',  :require => false if RUBY_VERSION < '1.9'
+
+if puppetversion && puppetversion < '5.0' && RUBY_VERSION >= '2.1.9'
+  gem 'semantic_puppet', :require => false
+end

--- a/metadata.json
+++ b/metadata.json
@@ -50,10 +50,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }


### PR DESCRIPTION
This PR fixes metadata to become compatible with Puppet 4 and 5. It also adds Travis support for Puppet 5. To speed up Travis runs it removes testing (support) for Puppet than 3.7.
