### PR TITLE
Allow un-managed content in autofs maps

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -50,6 +50,9 @@
 # @param manage
 #   Boolean to manage mounts in `auto.master`. Setting it to false will result in `-null` in `auto.master`.
 #
+# @param manage_content
+#   Boolean to manage contents of map.
+#
 # @param file
 #   Specify the mounts to be mounted at mountpoint from a file.
 #
@@ -67,6 +70,7 @@ define autofs::map (
   Optional[String[1]] $mountpoint         = undef,
   Optional[String[1]] $maptype            = undef,
   Variant[String[1], Boolean] $manage     = true,
+  Boolean $manage_content                 = true,
   Optional[String[1]] $options            = undef,
 ) {
   $mnt = $name
@@ -76,9 +80,10 @@ define autofs::map (
   $mappath_real = pick($mappath, "/etc/auto.${name}")
 
   # functionality
-  $content = $file ? {
-    undef   => template('autofs/mountmap.erb'),
-    default => undef,
+  if $manage_content == true and $file == undef {
+    $content = template('autofs/mountmap.erb')
+  } else {
+    $content = undef
   }
 
   file { "autofs__map_${mapname_real}":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -164,9 +164,10 @@ describe 'autofs' do
         it { is_expected.to have_autofs__map_resource_count(1) }
         it do
           is_expected.to contain_autofs__map('home').only_with(
-            'mountpoint' => 'home',
-            'mounts'     => ['spec nfsserver:/path/to/spec', 'test nfsserver:/path/to/test'],
-            'manage'     => true,
+            'mountpoint'     => 'home',
+            'mounts'         => ['spec nfsserver:/path/to/spec', 'test nfsserver:/path/to/test'],
+            'manage'         => true,
+            'manage_content' => true,
           )
         end
 
@@ -241,9 +242,10 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'   => 'test',
-          'mounts' => [],
-          'manage' => true,
+          'name'           => 'test',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -262,10 +264,11 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'mounts'     => [],
-          'manage'     => true,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -281,10 +284,11 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'    => 'test',
-          'mappath' => '/etc/auto.testing',
-          'mounts'  => [],
-          'manage'  => true,
+          'name'           => 'test',
+          'mappath'        => '/etc/auto.testing',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -300,11 +304,12 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'maptype'    => 'nis',
-          'mounts'     => [],
-          'manage'     => true,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'maptype'        => 'nis',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -320,12 +325,13 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'maptype'    => 'nis',
-          'mapname'    => 'auto.testing',
-          'mounts'     => [],
-          'manage'     => true,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'maptype'        => 'nis',
+          'mapname'        => 'auto.testing',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -344,11 +350,12 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'maptype'    => 'nis',
-          'mounts'     => [],
-          'manage'     => false,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'maptype'        => 'nis',
+          'mounts'         => [],
+          'manage'         => false,
+          'manage_content' => true,
         )
       end
 
@@ -364,10 +371,11 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'mounts'     => [],
-          'manage'     => false,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'mounts'         => [],
+          'manage'         => false,
+          'manage_content' => true,
         )
       end
     end
@@ -378,10 +386,11 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'    => 'test',
-          'options' => 'ro',
-          'mounts'  => [],
-          'manage'  => true,
+          'name'           => 'test',
+          'options'        => 'ro',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -400,11 +409,12 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'options'    => 'ro',
-          'mounts'     => [],
-          'manage'     => true,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'options'        => 'ro',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -420,12 +430,13 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'maptype'    => 'nis',
-          'options'    => 'ro',
-          'mounts'     => [],
-          'manage'     => true,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'maptype'        => 'nis',
+          'options'        => 'ro',
+          'mounts'         => [],
+          'manage'         => true,
+          'manage_content' => true,
         )
       end
 
@@ -441,11 +452,12 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test').only_with(
-          'name'       => 'test',
-          'mountpoint' => 'mountpoint',
-          'options'    => 'ro',
-          'mounts'     => [],
-          'manage'     => false,
+          'name'           => 'test',
+          'mountpoint'     => 'mountpoint',
+          'options'        => 'ro',
+          'mounts'         => [],
+          'manage'         => false,
+          'manage_content' => true,
         )
       end
     end
@@ -467,68 +479,75 @@ describe 'autofs' do
 
       it do
         is_expected.to contain_autofs__map('test1').only_with(
-          'manage'     => true,
-          'mounts'     => [],
-          'name'       => 'test1',
+          'manage'         => true,
+          'manage_content' => true,
+          'mounts'         => [],
+          'name'           => 'test1',
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test2').only_with(
-          'manage'     => true,
-          'mountpoint' => 'mountpoint2',
-          'mounts'     => [],
-          'name'       => 'test2',
+          'manage'         => true,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint2',
+          'mounts'         => [],
+          'name'           => 'test2',
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test3').only_with(
-          'manage'     => true,
-          'mountpoint' => 'mountpoint3',
-          'mounts'     => [],
-          'name'       => 'test3',
-          'options'    => 'ro',
+          'manage'         => true,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint3',
+          'mounts'         => [],
+          'name'           => 'test3',
+          'options'        => 'ro',
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test4').only_with(
-          'name'       => 'test4',
-          'manage'     => true,
-          'mountpoint' => 'mountpoint4',
-          'maptype'    => 'nis',
-          'mounts'     => [],
+          'name'           => 'test4',
+          'manage'         => true,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint4',
+          'maptype'        => 'nis',
+          'mounts'         => [],
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test5').only_with(
-          'name'       => 'test5',
-          'manage'     => false,
-          'mountpoint' => 'mountpoint5',
-          'mounts'     => [],
+          'name'           => 'test5',
+          'manage'         => false,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint5',
+          'mounts'         => [],
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test6').only_with(
-          'name'       => 'test6',
-          'manage'     => true,
-          'mountpoint' => 'mountpoint6',
-          'mappath'    => '/etc/auto.testing',
-          'mounts'     => [],
+          'name'           => 'test6',
+          'manage'         => true,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint6',
+          'mappath'        => '/etc/auto.testing',
+          'mounts'         => [],
         )
       end
 
       it do
         is_expected.to contain_autofs__map('test7').only_with(
-          'name'       => 'test7',
-          'manage'     => true,
-          'mountpoint' => 'mountpoint7',
-          'maptype'    => 'nis',
-          'mapname'    => 'auto.test',
-          'mounts'     => [],
+          'name'           => 'test7',
+          'manage'         => true,
+          'manage_content' => true,
+          'mountpoint'     => 'mountpoint7',
+          'maptype'        => 'nis',
+          'mapname'        => 'auto.test',
+          'mounts'         => [],
         )
       end
 

--- a/spec/classes/use_cases_spec.rb
+++ b/spec/classes/use_cases_spec.rb
@@ -45,10 +45,11 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('home').only_with(
-            'manage'     => true,
-            'mountpoint' => 'home',
-            'mounts'     => ['server:/home/a', 'server:/home/b', 'server:/home/c'],
-            'name'       => 'home',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'home',
+            'mounts'         => ['server:/home/a', 'server:/home/b', 'server:/home/c'],
+            'name'           => 'home',
           )
         end
 
@@ -91,11 +92,12 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.home').only_with(
-            'manage'     => true,
-            'maptype'    => 'yp',
-            'mountpoint' => 'home',
-            'mounts'     => [],
-            'name'       => 'auto.home',
+            'manage'         => true,
+            'manage_content' => true,
+            'maptype'        => 'yp',
+            'mountpoint'     => 'home',
+            'mounts'         => [],
+            'name'           => 'auto.home',
           )
         end
 
@@ -129,11 +131,12 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.home').only_with(
-            'manage'     => true,
-            'maptype'    => 'yp',
-            'mountpoint' => 'home',
-            'mounts'     => [],
-            'name'       => 'auto.home',
+            'manage'         => true,
+            'manage_content' => true,
+            'maptype'        => 'yp',
+            'mountpoint'     => 'home',
+            'mounts'         => [],
+            'name'           => 'auto.home',
           )
         end
 
@@ -167,11 +170,12 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.home').only_with(
-            'manage'     => true,
-            'maptype'    => 'yp',
-            'mountpoint' => 'home',
-            'mounts'     => [],
-            'name'       => 'auto.home',
+            'manage'         => true,
+            'manage_content' => true,
+            'maptype'        => 'yp',
+            'mountpoint'     => 'home',
+            'mounts'         => [],
+            'name'           => 'auto.home',
           )
         end
 
@@ -208,20 +212,22 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('data').only_with(
-            'manage'     => true,
-            'mountpoint' => 'data',
-            'mounts'     => ['server:/data/a', 'server:/data/b', 'server:/data/c'],
-            'name'       => 'data',
-            'options'    => '--vers=3',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'data',
+            'mounts'         => ['server:/data/a', 'server:/data/b', 'server:/data/c'],
+            'name'           => 'data',
+            'options'        => '--vers=3',
           )
         end
 
         it do
           is_expected.to contain_autofs__map('home').only_with(
-            'manage'     => true,
-            'mountpoint' => 'home',
-            'mounts'     => ['server:/home/a', 'server:/home/b', 'server:/home/c'],
-            'name'       => 'home',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'home',
+            'mounts'         => ['server:/home/a', 'server:/home/b', 'server:/home/c'],
+            'name'           => 'home',
           )
         end
 
@@ -269,10 +275,11 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('ftp').only_with(
-            'manage'     => true,
-            'mountpoint' => 'ftp/projects',
-            'mounts'     => ['server:/ftp/a', 'server:/ftp/b', 'server:/ftp/c'],
-            'name'       => 'ftp',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'ftp/projects',
+            'mounts'         => ['server:/ftp/a', 'server:/ftp/b', 'server:/ftp/c'],
+            'name'           => 'ftp',
           )
         end
 
@@ -310,9 +317,10 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('ftp').only_with(
-            'manage'     => true,
-            'mounts'     => ['server:/ftp/a', 'server:/ftp/b', 'server:/ftp/c'],
-            'name'       => 'ftp',
+            'manage'         => true,
+            'manage_content' => true,
+            'mounts'         => ['server:/ftp/a', 'server:/ftp/b', 'server:/ftp/c'],
+            'name'           => 'ftp',
           )
         end
 
@@ -351,10 +359,11 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('home').only_with(
-            'manage'     => false,
-            'mountpoint' => 'home',
-            'mounts'     => [],
-            'name'       => 'home',
+            'manage'         => false,
+            'manage_content' => true,
+            'mountpoint'     => 'home',
+            'mounts'         => [],
+            'name'           => 'home',
           )
         end
 
@@ -370,6 +379,22 @@ describe 'autofs' do
         it { is_expected.to contain_file('autofs__map_mountmap_home').with_path('/etc/auto.home') }
         it { is_expected.to contain_concat__fragment('auto.master_home').with_content("/home -null\n") }
         it { is_expected.to contain_concat__fragment('auto.master_linebreak').with_content("\n") }
+
+        context 'with manage_content false' do
+          let(:params) do
+            {
+              maps: {
+                'home' => {
+                  'mountpoint'     => 'home',
+                  'manage'         => true,
+                  'manage_content' => false,
+                },
+              },
+            }
+          end
+
+          it { is_expected.to contain_file('autofs__map_mountmap_home').with_content(nil) }
+        end
       end
 
       context 'should not load NIS maps' do
@@ -387,10 +412,11 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('home').only_with(
-            'manage'     => true,
-            'mountpoint' => 'home',
-            'mounts'     => [],
-            'name'       => 'home',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'home',
+            'mounts'         => [],
+            'name'           => 'home',
           )
         end
 
@@ -426,11 +452,12 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.proj').only_with(
-            'manage'     => true,
-            'maptype'    => 'yp',
-            'mountpoint' => 'proj',
-            'mounts'     => [],
-            'name'       => 'auto.proj',
+            'manage'         => true,
+            'manage_content' => true,
+            'maptype'        => 'yp',
+            'mountpoint'     => 'proj',
+            'mounts'         => [],
+            'name'           => 'auto.proj',
           )
         end
 
@@ -466,11 +493,12 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.proj').only_with(
-            'file'       => '/path/to/file/with/mounts',
-            'manage'     => true,
-            'mountpoint' => 'proj',
-            'mounts'     => [],
-            'name'       => 'auto.proj',
+            'file'           => '/path/to/file/with/mounts',
+            'manage'         => true,
+            'manage_content' => true,
+            'mountpoint'     => 'proj',
+            'mounts'         => [],
+            'name'           => 'auto.proj',
           )
         end
 
@@ -511,12 +539,13 @@ describe 'autofs' do
         # class autofs
         it do
           is_expected.to contain_autofs__map('auto.proj').only_with(
-            'file'       => '/path/to/file/with/mounts',
-            'manage'     => true,
-            'mappath'    => '/etc/auto.proj',
-            'mountpoint' => 'proj',
-            'mounts'     => [],
-            'name'       => 'auto.proj',
+            'file'           => '/path/to/file/with/mounts',
+            'manage'         => true,
+            'manage_content' => true,
+            'mappath'        => '/etc/auto.proj',
+            'mountpoint'     => 'proj',
+            'mounts'         => [],
+            'name'           => 'auto.proj',
           )
         end
 

--- a/spec/defines/maps_spec.rb
+++ b/spec/defines/maps_spec.rb
@@ -88,6 +88,14 @@ describe 'autofs::map' do
           is_expected.to contain_file('autofs__map_string')
         }
       end
+
+      context 'with manage_content set to false' do
+        let(:params) { { manage_content: false } }
+
+        it do
+          is_expected.to contain_file('autofs__map_mountmap_example').with('content' => nil)
+        end
+      end
     end
 
     describe "on #{os} with non-functional parameters set" do


### PR DESCRIPTION
Allows having maps added to correct auto.* files but leave the contents of the map-file un-managed. This makes it possible having a different source add information to the map file.

Should be merged after #39 since it's based on said pull request.